### PR TITLE
Add a rule to enforce semantic versioning

### DIFF
--- a/spectral-ruleset-govuk-public/ruleset.yaml
+++ b/spectral-ruleset-govuk-public/ruleset.yaml
@@ -1,2 +1,11 @@
 extends:
   - [spectral:oas, all]
+rules:
+  semver:
+    severity: error
+    message: Version should use semantic versioning. {{value}} is not a valid version.
+    given: $.info.version
+    then:
+      function: pattern
+      functionOptions:
+        match: "^([0-9]+.[0-9]+.[0-9]+)$"

--- a/spectral-ruleset-govuk-public/test/semver.test.js
+++ b/spectral-ruleset-govuk-public/test/semver.test.js
@@ -1,0 +1,40 @@
+const { retrieveDocument, setupSpectral, getErrors, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('semver', () => {
+    test('fails when not a number', async () => {
+        const spectral = await setupSpectral('ruleset.yaml')
+        const document = retrieveDocument('semver/invalid-letters.yaml')
+
+        const results = resultsForCode(await spectral.run(document), 'semver')
+
+        expect(results).toHaveLength(1)
+        expect(results[0]['message']).toEqual('Version should use semantic versioning. abc is not a valid version.')
+    })
+
+    test('fails when empty', async () => {
+        const spectral = await setupSpectral('ruleset.yaml')
+        const document = retrieveDocument('semver/invalid-empty.yaml')
+
+        const results = resultsForCode(await spectral.run(document), 'semver')
+
+        expect(results).toHaveLength(1)
+    })
+
+    test('fails when there is a major and minor version but no patch', async () => {
+        const spectral = await setupSpectral('ruleset.yaml')
+        const document = retrieveDocument('semver/invalid-no-patch.yaml')
+
+        const results = resultsForCode(await spectral.run(document), 'semver')
+
+        expect(results).toHaveLength(1)
+    })
+
+    test('passes when numbers have multiple digits', async () => {
+        const spectral = await setupSpectral('ruleset.yaml')
+        const document = retrieveDocument('semver/valid-complex-number.yaml')
+
+        const results = resultsForCode(await spectral.run(document), 'semver')
+
+        expect(results).toHaveLength(0)
+    })
+})

--- a/spectral-ruleset-govuk-public/test/testdata/complete/valid-2.0.0.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/complete/valid-2.0.0.yaml
@@ -1,5 +1,5 @@
 swagger: '2.0'
 info:
   title: ''
-  version: ''
+  version: '1.0.0'
 paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/complete/valid-3.0.0.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/complete/valid-3.0.0.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.0
 info:
   title: ''
-  version: ''
+  version: '1.0.0'
 paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/semver/invalid-empty.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/semver/invalid-empty.yaml
@@ -1,5 +1,5 @@
 openapi: 3.1.0
 info:
   title: ''
-  version: '1.0.0'
+  version: ''
 paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/semver/invalid-letters.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/semver/invalid-letters.yaml
@@ -1,5 +1,5 @@
 openapi: 3.1.0
 info:
   title: ''
-  version: '1.0.0'
+  version: 'abc'
 paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/semver/invalid-no-patch.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/semver/invalid-no-patch.yaml
@@ -1,5 +1,5 @@
 openapi: 3.1.0
 info:
   title: ''
-  version: '1.0.0'
+  version: '1.0'
 paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/semver/valid-complex-number.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/semver/valid-complex-number.yaml
@@ -1,5 +1,5 @@
 openapi: 3.1.0
 info:
   title: ''
-  version: '1.0.0'
+  version: '10.0.500'
 paths: {}


### PR DESCRIPTION
The original complete tests have been amended so that they have the correct
versioning and those tests will still pass.

The semver tests only run the semver rule, as otherwise we're testing the
complete spec multiple times.