### PR TITLE
Publish package to NPM on `main`

### DIFF
--- a/.github/workflows/spectral-ruleset-govuk-public-ci.yml
+++ b/.github/workflows/spectral-ruleset-govuk-public-ci.yml
@@ -28,3 +28,22 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm test
+
+  publish:
+    environment: npm
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
+        cache: 'npm'
+        cache-dependency-path: spectral-ruleset-govuk-public/package-lock.json
+    - uses: JS-DevTools/npm-publish@v1
+      with:
+        package: spectral-ruleset-govuk-public/package.json
+        access: public
+        token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Following the steps from [0], with some inspiration from [1] and [2], we
can set up the ability to automagically publish to NPM on a GitHub
Release.

Because we're running in a monorepo, however, we need to be a bit more
careful about the triggers for a release. Although it'd be ideal to
follow [1] and [2]'s recommendation to do it based on a Release being
`publishing`, this isn't possible as it means the ?

We can utilise the `npm-publish` action, as it'll only release when we
need to, leading to fewer failed builds, or us having work out whether
it's already been uploaded yet.

We need to make sure that this only triggers on `main` and that it's
wrapped in an Environment to restrict access to the secret outside of
where it's intended to be,
as well as making it easier to visualise the releases in i.e. Webhooks.

Finally, we make sure that the `publish` job requires `build` to
complete, otherwise we risk them being in parallel, and releasing before
functionally correct.

[0]: https://snyk.io/blog/github-actions-to-securely-publish-npm-packages/
[1]: https://sergiodxa.com/articles/github-actions-npm-publish
[2]: https://michaelzanggl.com/articles/github-actions-cd-setup/
