### PR TITLE
Add scope to package

### DIFF
--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "spectral-ruleset-govuk-public",
+  "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
   "version": "0.1.0",
   "description": "Spectral ruleset for public UK government APIs",
   "main": "ruleset.yaml",


### PR DESCRIPTION
Instead of releasing to the public namespace on NPM, which has the
chance of clashing with other packages, we can instead use our own
organisation's scoping, which requires prefixing in our `package.json`.

This was missed from changes going in as part of
70b25df28c738fcbd6dc9079189984368f330a20.
