### PR TITLE
Automagically label PRs with the repos they affect

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+'🔧 GitHub Configuration':
+  - '.github/**/*'
+'📁 Repo: spectral-ruleset-govuk-public':
+  - 'spectral-ruleset-govuk-public/**/*'
+'📚 Documentation':
+  - '**/*.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@69da01b8e0929f147b8943611bee75ee4175a49e
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
To improve visibility of what repos are changing in PRs, we can
utilise the `labeler` Action to auto-label PRs with what's affected.

We also want to enable `sync-labels` to make sure that changes to files
once the PR is raised to make sure that the labels stay updated.

Closes #5.
