### PR TITLE
Add id-token permission

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -16,6 +16,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Since version 2, the scorecards workflow requires id-token to have
write access: https://github.com/ossf/scorecard-action