### PR TITLE
Add X- header rule

### DIFF
--- a/adrs/0004-no-x-headers.md
+++ b/adrs/0004-no-x-headers.md
@@ -1,0 +1,13 @@
+# Header names should not begin with X-
+
+---
+creation_date: 2022-11-16
+decision_date: 2022-11-16
+status: accepted
+---
+
+## Context
+X- was originally used as a prefix for experimental HTTP headers, however it led to unstandardised headers being used in production. Therefore [rfc6648](https://datatracker.ietf.org/doc/html/rfc6648) deprecates this convention. Other rulesets have added rules to disallow X- headers, for example the [Italian government's ruleset](https://github.com/italia/api-oas-checker/blob/master/rules/headers.yml) and [APIs You Won't Hate](https://github.com/apisyouwonthate/style-guide/blob/main/src/ruleset.ts). 
+
+## Decision
+Add rules that headers in requests and responses shouldn't start with X-.

--- a/spectral-ruleset-govuk-public/package-lock.json
+++ b/spectral-ruleset-govuk-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spectral-ruleset-govuk-public",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spectral-ruleset-govuk-public",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "OGL-UK-3.0",
       "devDependencies": {
         "@jamietanna/spectral-test-harness": "^0.2.0",

--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Spectral ruleset for public UK government APIs",
   "main": "ruleset.yaml",
   "license": "OGL-UK-3.0",

--- a/spectral-ruleset-govuk-public/ruleset.yaml
+++ b/spectral-ruleset-govuk-public/ruleset.yaml
@@ -42,4 +42,21 @@ rules:
           - 'https'
     message: Servers must use the HTTPS protocol
     formats: ["oas2"]
-
+  no-x-headers:
+    severity: error
+    message: Headers should not use the X- prefix
+    given: "$..parameters[?(@.in === 'header')].name"
+    then:
+      function: pattern
+      functionOptions:
+        match:
+          "^([^xX]|.[^-])"
+  no-x-response-headers:
+    severity: error
+    message: Headers should not use the X- prefix
+    given: "$..headers.*~"
+    then:
+      function: pattern
+      functionOptions:
+        match:
+          "^([^xX]|.[^-])"

--- a/spectral-ruleset-govuk-public/test/testdata/x-header/invalid-request.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/x-header/invalid-request.yaml
@@ -1,0 +1,12 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+  "/ping":
+    get:
+      parameters:
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string

--- a/spectral-ruleset-govuk-public/test/testdata/x-header/invalid-response.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/x-header/invalid-response.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+"/ping":
+  get:
+    summary: Checks if the server is alive.
+    responses:
+      '200':
+        description: OK
+        headers:
+          X-RateLimit-Limit:
+            schema:
+              type: integer

--- a/spectral-ruleset-govuk-public/test/testdata/x-header/valid-request.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/x-header/valid-request.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+  /ping:
+    get:
+      summary: Checks if the server is alive
+      parameters:
+        - in: header
+          name: Request-ID
+          schema:
+            type: string

--- a/spectral-ruleset-govuk-public/test/testdata/x-header/valid-response.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/x-header/valid-response.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+"/ping":
+  get:
+    summary: Checks if the server is alive.
+    responses:
+      '200':
+        description: OK
+        headers:
+          RateLimit-Limit:
+            schema:
+              type: integer

--- a/spectral-ruleset-govuk-public/test/x-header.test.js
+++ b/spectral-ruleset-govuk-public/test/x-header.test.js
@@ -1,0 +1,41 @@
+const { retrieveDocument, setupSpectral, getErrors, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('X- headers', () => {
+  test('fails when request headers starts with X-', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('x-header/invalid-request.yaml')
+
+    const results = getErrors(await spectral.run(document))
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('Headers should not use the X- prefix')
+  })
+
+  test('passes when request headers do not start with X-', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('x-header/valid-request.yaml')
+
+    const results = getErrors(await spectral.run(document))
+
+    expect(results).toHaveLength(0)
+  })
+
+  test('fails when response headers start with X-', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('x-header/invalid-response.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'no-x-response-headers')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('Headers should not use the X- prefix')
+  })
+
+  test('passes when response headers do not start with X-', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('x-header/valid-response.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'no-x-response-headers')
+
+    expect(results).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
This creates a new minor npm version with 2 new rules disallowing the X- prefix in headers.