### PR TITLE
Add domain rule

### DIFF
--- a/adrs/0007-domain-name.md
+++ b/adrs/0007-domain-name.md
@@ -1,0 +1,13 @@
+# Domain name must follow gov.uk guidance
+
+---
+creation_date: 2022-12-02
+decision_date: 2022-12-02
+status: accepted
+---
+
+## Context
+The [guidance on gov.uk](https://www.gov.uk/guidance/get-an-api-domain-on-govuk) specifies that an API domain should be between 3 and 63 characters long and contain only alphanumeric characters (0-9 and a-z) and the ‘-’ (dash) symbol.
+
+## Decision
+Add a rule to check that the domain follows our guidance.

--- a/spectral-ruleset-govuk-public/package-lock.json
+++ b/spectral-ruleset-govuk-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "OGL-UK-3.0",
       "devDependencies": {
         "@jamietanna/spectral-test-harness": "^0.2.0",

--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Spectral ruleset for public UK government APIs",
   "main": "ruleset.yaml",
   "license": "OGL-UK-3.0",

--- a/spectral-ruleset-govuk-public/ruleset.yaml
+++ b/spectral-ruleset-govuk-public/ruleset.yaml
@@ -74,3 +74,11 @@ rules:
     then:
       field: "info.contact"
       function: truthy
+  domain-name:
+    severity: error
+    given: "$.servers[*].url"
+    description: "The domain name must be between 3 and 63 characters long, and contain only alphanumeric characters (0-9 and a-z) and the ‘-’ (dash) symbol. It should also use dashes between words to make your domain easy to read - for example, vehicle-registration-number.api.gov.uk."
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\\.[a-zA-Z]{2,})+$"

--- a/spectral-ruleset-govuk-public/test/domain.test.js
+++ b/spectral-ruleset-govuk-public/test/domain.test.js
@@ -1,0 +1,32 @@
+const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('domain name', () => {
+  test('fails when the domain name is less than 3 characters', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('domain/invalid-too-short.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'domain-name')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('The domain name must be between 3 and 63 characters long, and contain only alphanumeric characters (0-9 and a-z) and the ‘-’ (dash) symbol. It should also use dashes between words to make your domain easy to read - for example, vehicle-registration-number.api.gov.uk.')
+  })
+
+  test('fails when the domain name contains a special character', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('domain/invalid-special-character.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'domain-name')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('The domain name must be between 3 and 63 characters long, and contain only alphanumeric characters (0-9 and a-z) and the ‘-’ (dash) symbol. It should also use dashes between words to make your domain easy to read - for example, vehicle-registration-number.api.gov.uk.')
+  })
+
+  test('passes when the domain contains the correct characters', async () => {
+    const spectral = await setupSpectral('ruleset.yaml')
+    const document = retrieveDocument('domain/valid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'domain-name')
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/spectral-ruleset-govuk-public/test/testdata/domain/invalid-special-character.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/domain/invalid-special-character.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths: {}
+servers:
+  - url: 'vehicle-registration-number-*.api.gov.uk'

--- a/spectral-ruleset-govuk-public/test/testdata/domain/invalid-too-short.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/domain/invalid-too-short.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths: {}
+servers:
+  - url: 've.api.gov.uk'

--- a/spectral-ruleset-govuk-public/test/testdata/domain/valid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/domain/valid.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths: {}
+servers:
+  - url: 'vehicle-registration-number.api.gov.uk'


### PR DESCRIPTION
We can use a regex to check that the domain name follows the guidance on
gov.uk.

The regex is based on the accepted answer to this question:
https://stackoverflow.com/questions/26093545/how-to-validate-domain-name-using-regex

However to escape the `.` character we need to use two backslashes, as the
backslash is an escape character in json:
https://stackoverflow.com/questions/30739738/json-schema-validation-with-escaped-characters-in-patterns-fails