### PR TITLE
Split the rulesets into 3 levels

### DIFF
--- a/spectral-ruleset-govuk-public/package-lock.json
+++ b/spectral-ruleset-govuk-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "OGL-UK-3.0",
       "devDependencies": {
         "@jamietanna/spectral-test-harness": "^0.2.0",

--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Spectral ruleset for public UK government APIs",
   "main": "ruleset.yaml",
   "license": "OGL-UK-3.0",

--- a/spectral-ruleset-govuk-public/ruleset-high.yaml
+++ b/spectral-ruleset-govuk-public/ruleset-high.yaml
@@ -1,0 +1,46 @@
+extends:
+  - 'ruleset-medium.yaml'
+rules:
+  oas3-strict:
+    severity: error
+    message: OpenAPI version must be 3.1.0
+    given: "$"
+    then:
+      field: openapi
+      function: pattern
+      functionOptions:
+        match: '3\.1\.0'
+
+  license-strict:
+    severity: error
+    message: "The licence should be Apache 2.0"
+    given: $.info.license.identifier
+    then:
+      function: pattern
+      functionOptions:
+        match: 'Apache-2\.0'
+
+  license-url:
+    severity: error
+    message: "The licence url should link to the correct Apache 2.0 site."
+    given: $.info.license.url
+    then:
+      function: pattern
+      functionOptions:
+        match: 'https://www\.apache\.org/licenses/LICENSE-2\.0'
+
+  not-acceptable:
+    severity: error
+    given: "$.paths.[*][get,put,post,delete,patch].responses"
+    description: "Resources that can provide a response body must declare a response for an HTTP 406 Not Acceptable"
+    then:
+      field: "406"
+      function: truthy
+
+  unsupported-media-type:
+    severity: error
+    given: "$.paths.[*][put,post,patch].responses"
+    description: "Resources that consume a request body must declare a response for an HTTP 415 Unsupported Media Type"
+    then:
+      field: "415"
+      function: truthy

--- a/spectral-ruleset-govuk-public/ruleset-medium.yaml
+++ b/spectral-ruleset-govuk-public/ruleset-medium.yaml
@@ -1,0 +1,60 @@
+extends:
+  - 'ruleset.yaml'
+rules:
+  oas3-minimum:
+    severity: error
+    message: OpenAPI version must be 3 or higher
+    given: "$"
+    then:
+      field: openapi
+      function: pattern
+      functionOptions:
+        match: '3\.[0-9]?\.[0-9]'
+
+  license:
+    severity: error
+    message: "The license should be a popular open source licence, for example: https://opensource.org/licenses/?categories=popular-strong-community"
+    given: $.info.license.identifier
+    then:
+      function: enumeration
+      functionOptions:
+        values:
+          - "Apache-2.0"
+          - "CDDL-1.0"
+          - "EPL-2.0"
+          - "GPL-2.0"
+          - "GPL-3.0-only"
+          - "LGPL-2.1"
+          - "LGPL-3.0-only"
+          - "LGPL-2.0-only"
+          - "MPL-2.0"
+          - "BSD-2-Clause"
+          - "BSD-3-Clause"
+          - "MIT"
+
+  operation-id:
+    severity: error
+    message: "Every endpoint must have a unique operationId specified."
+    given: "$.paths.*.*"
+    then:
+      function: truthy
+      field: operationId
+
+  semver:
+    severity: error
+    message: Version should use semantic versioning. {{value}} is not a valid version.
+    given: $.info.version
+    then:
+      function: pattern
+      functionOptions:
+        match: '^([0-9]+\.[0-9]+\.[0-9]+)$'
+
+  paths-kebab-case:
+    severity: error
+    given: $.paths[*]~
+    message: "Paths should use kebab case."
+    then:
+      function: pattern
+      functionOptions:
+        match: '^(\/[a-z0-9-.]+|\/{[a-zA-Z0-9_]+})+$'
+

--- a/spectral-ruleset-govuk-public/ruleset.yaml
+++ b/spectral-ruleset-govuk-public/ruleset.yaml
@@ -1,20 +1,6 @@
 extends:
   - [spectral:oas, all]
 rules:
-  not-acceptable:
-    severity: error
-    given: "$.paths.[*][get,put,post,delete,patch].responses"
-    description: "Resources that can provide a response body must declare a response for an HTTP 406 Not Acceptable"
-    then:
-      field: "406"
-      function: truthy
-  unsupported-media-type:
-    severity: error
-    given: "$.paths.[*][put,post,patch].responses"
-    description: "Resources that consume a request body must declare a response for an HTTP 415 Unsupported Media Type"
-    then:
-      field: "415"
-      function: truthy
   oas3-always-use-https:
     severity: error
     message: Servers must use the HTTPS protocol except when using localhost

--- a/spectral-ruleset-govuk-public/ruleset.yaml
+++ b/spectral-ruleset-govuk-public/ruleset.yaml
@@ -1,14 +1,6 @@
 extends:
   - [spectral:oas, all]
 rules:
-  semver:
-    severity: error
-    message: Version should use semantic versioning. {{value}} is not a valid version.
-    given: $.info.version
-    then:
-      function: pattern
-      functionOptions:
-        match: "^([0-9]+.[0-9]+.[0-9]+)$"
   not-acceptable:
     severity: error
     given: "$.paths.[*][get,put,post,delete,patch].responses"

--- a/spectral-ruleset-govuk-public/test/license-strict.test.js
+++ b/spectral-ruleset-govuk-public/test/license-strict.test.js
@@ -1,0 +1,41 @@
+const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('license', () => {
+  test('fails when the license identifier is not Apache 2.0', async () => {
+    const spectral = await setupSpectral('ruleset-high.yaml')
+    const document = retrieveDocument('license/strict/invalid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'license-strict')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('The licence should be Apache 2.0')
+  })
+
+  test('passes when license identifier is one of the recommended OS licenses', async () => {
+    const spectral = await setupSpectral('ruleset-high.yaml')
+    const document = retrieveDocument('license/strict/valid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'license-strict')
+
+    expect(results).toHaveLength(0)
+  })
+
+  test('fails when the license url is incorrect', async () => {
+    const spectral = await setupSpectral('ruleset-high.yaml')
+    const document = retrieveDocument('license/strict/invalid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'license-url')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('The licence url should link to the correct Apache 2.0 site.')
+  })
+
+  test('passes when license url is correct', async () => {
+    const spectral = await setupSpectral('ruleset-high.yaml')
+    const document = retrieveDocument('license/strict/valid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'license-url')
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/spectral-ruleset-govuk-public/test/license.test.js
+++ b/spectral-ruleset-govuk-public/test/license.test.js
@@ -1,0 +1,22 @@
+const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('license', () => {
+  test('fails when the license identifier is not one of the recommended OS licenses', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('license/invalid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'license')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('The license should be a popular open source licence, for example: https://opensource.org/licenses/?categories=popular-strong-community')
+  })
+
+  test('passes when license identifier is one of the recommended OS licenses', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('license/valid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'license')
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/spectral-ruleset-govuk-public/test/not-acceptable.test.js
+++ b/spectral-ruleset-govuk-public/test/not-acceptable.test.js
@@ -2,7 +2,7 @@ const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna
 
 describe('not-acceptable', () => {
   async function isNotRequired (method) {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-high.yaml')
     const document = retrieveDocument(`not-acceptable/absent-${method}.yaml`)
 
     const results = resultsForCode(await spectral.run(document), 'not-acceptable')
@@ -11,7 +11,7 @@ describe('not-acceptable', () => {
   }
 
   async function isRequired (method) {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-high.yaml')
     const document = retrieveDocument(`not-acceptable/absent-${method}.yaml`)
 
     const results = resultsForCode(await spectral.run(document), 'not-acceptable')
@@ -37,7 +37,7 @@ describe('not-acceptable', () => {
   })
 
   test('passes when 406 is present', async () => {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-high.yaml')
     const document = retrieveDocument('not-acceptable/valid.yaml')
 
     const results = resultsForCode(await spectral.run(document), 'not-acceptable')

--- a/spectral-ruleset-govuk-public/test/oas3.test.js
+++ b/spectral-ruleset-govuk-public/test/oas3.test.js
@@ -28,4 +28,14 @@ describe('oas3', () => {
 
     expect(results).toHaveLength(0)
   })
+
+  test('oas3-strict fails when oas version is 3.0.0', async () => {
+    const spectral = await setupSpectral('ruleset-high.yaml')
+    const document = retrieveDocument('oas3/3.0.0.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'oas3-strict')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('OpenAPI version must be 3.1.0')
+  })
 })

--- a/spectral-ruleset-govuk-public/test/oas3.test.js
+++ b/spectral-ruleset-govuk-public/test/oas3.test.js
@@ -1,0 +1,31 @@
+const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('oas3', () => {
+  test('fails when the oas version is lower than 3', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('oas3/2.0.0.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'oas3-minimum')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('OpenAPI version must be 3 or higher')
+  })
+
+  test('passes when oas version is 3.1.0', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('oas3/3.1.0.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'oas3-minimum')
+
+    expect(results).toHaveLength(0)
+  })
+
+  test('oas3-minimum passes when oas version is 3.0.0', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('oas3/3.0.0.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'oas3-minimum')
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/spectral-ruleset-govuk-public/test/operation-id.test.js
+++ b/spectral-ruleset-govuk-public/test/operation-id.test.js
@@ -1,0 +1,22 @@
+const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('OperationId', () => {
+  test('fails when operationId is not present', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('operation-id/invalid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'operation-id')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('Every endpoint must have a unique operationId specified.')
+  })
+
+  test('passes when operationId is present', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('operation-id/valid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'operation-id')
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/spectral-ruleset-govuk-public/test/paths-kebab-case.test.js
+++ b/spectral-ruleset-govuk-public/test/paths-kebab-case.test.js
@@ -1,0 +1,22 @@
+const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna/spectral-test-harness')
+
+describe('Paths kebab case', () => {
+  test('fails when the path is not kebab case', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('paths-kebab-case/invalid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'paths-kebab-case')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].message).toEqual('Paths should use kebab case.')
+  })
+
+  test('passes when the path is kebab case', async () => {
+    const spectral = await setupSpectral('ruleset-medium.yaml')
+    const document = retrieveDocument('paths-kebab-case/valid.yaml')
+
+    const results = resultsForCode(await spectral.run(document), 'paths-kebab-case')
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/spectral-ruleset-govuk-public/test/semver.test.js
+++ b/spectral-ruleset-govuk-public/test/semver.test.js
@@ -2,7 +2,7 @@ const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna
 
 describe('semver', () => {
   test('fails when not a number', async () => {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-medium.yaml')
     const document = retrieveDocument('semver/invalid-letters.yaml')
 
     const results = resultsForCode(await spectral.run(document), 'semver')
@@ -12,7 +12,7 @@ describe('semver', () => {
   })
 
   test('fails when empty', async () => {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-medium.yaml')
     const document = retrieveDocument('semver/invalid-empty.yaml')
 
     const results = resultsForCode(await spectral.run(document), 'semver')
@@ -21,7 +21,7 @@ describe('semver', () => {
   })
 
   test('fails when there is a major and minor version but no patch', async () => {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-medium.yaml')
     const document = retrieveDocument('semver/invalid-no-patch.yaml')
 
     const results = resultsForCode(await spectral.run(document), 'semver')
@@ -30,7 +30,7 @@ describe('semver', () => {
   })
 
   test('passes when numbers have multiple digits', async () => {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-medium.yaml')
     const document = retrieveDocument('semver/valid-complex-number.yaml')
 
     const results = resultsForCode(await spectral.run(document), 'semver')

--- a/spectral-ruleset-govuk-public/test/testdata/complete/valid-3.1.0.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/complete/valid-3.1.0.yaml
@@ -8,4 +8,7 @@ info:
     "url": "https://www.example.com/support",
     "email": "support@example.com"
   }
+  license:
+    name: Apache 2.0
+    identifier: "Apache-2.0"
 paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/license/invalid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/license/invalid.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+  license:
+    name: EULA
+    identifier: EULA
+paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/license/strict/invalid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/license/strict/invalid.yaml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+  license:
+    name: MIT
+    identifier: "MIT"
+    url: https://opensource.org/license/mit/
+paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/license/strict/valid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/license/strict/valid.yaml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/license/valid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/license/valid.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+paths: {}

--- a/spectral-ruleset-govuk-public/test/testdata/oas3/2.0.0.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/oas3/2.0.0.yaml
@@ -1,0 +1,4 @@
+openapi: 2.0.0
+info:
+  title: ''
+  version: '1.0.0'

--- a/spectral-ruleset-govuk-public/test/testdata/oas3/3.0.0.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/oas3/3.0.0.yaml
@@ -1,0 +1,4 @@
+openapi: 3.0.0
+info:
+  title: ''
+  version: '1.0.0'

--- a/spectral-ruleset-govuk-public/test/testdata/oas3/3.1.0.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/oas3/3.1.0.yaml
@@ -1,0 +1,4 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'

--- a/spectral-ruleset-govuk-public/test/testdata/operation-id/invalid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/operation-id/invalid.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+  /ping:
+    get:
+      summary: Checks if the server is alive

--- a/spectral-ruleset-govuk-public/test/testdata/operation-id/valid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/operation-id/valid.yaml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+  /ping:
+    get:
+      summary: Checks if the server is alive
+      operationId: ping

--- a/spectral-ruleset-govuk-public/test/testdata/paths-kebab-case/invalid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/paths-kebab-case/invalid.yaml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+  /path_parameter:
+    get:
+      summary: Checks if the server is alive
+      operationId: ping

--- a/spectral-ruleset-govuk-public/test/testdata/paths-kebab-case/invalid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/paths-kebab-case/invalid.yaml
@@ -6,4 +6,3 @@ paths:
   /path_parameter:
     get:
       summary: Checks if the server is alive
-      operationId: ping

--- a/spectral-ruleset-govuk-public/test/testdata/paths-kebab-case/valid.yaml
+++ b/spectral-ruleset-govuk-public/test/testdata/paths-kebab-case/valid.yaml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: '1.0.0'
+paths:
+  /path-parameter:
+    get:
+      summary: Checks if the server is alive
+      operationId: ping

--- a/spectral-ruleset-govuk-public/test/unsupported-media-type.test.js
+++ b/spectral-ruleset-govuk-public/test/unsupported-media-type.test.js
@@ -2,7 +2,7 @@ const { retrieveDocument, setupSpectral, resultsForCode } = require('@jamietanna
 
 describe('unsupported-media-type', () => {
   async function isNotRequired (method) {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-high.yaml')
     const document = retrieveDocument(`unsupported-media-type/absent-${method}.yaml`)
 
     const results = resultsForCode(await spectral.run(document), 'unsupported-media-type')
@@ -11,7 +11,7 @@ describe('unsupported-media-type', () => {
   }
 
   async function isRequired (method) {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-high.yaml')
     const document = retrieveDocument(`unsupported-media-type/absent-${method}.yaml`)
 
     const results = resultsForCode(await spectral.run(document), 'unsupported-media-type')
@@ -37,7 +37,7 @@ describe('unsupported-media-type', () => {
   })
 
   test('passes when 415 is present', async () => {
-    const spectral = await setupSpectral('ruleset.yaml')
+    const spectral = await setupSpectral('ruleset-high.yaml')
     const document = retrieveDocument('unsupported-media-type/valid.yaml')
 
     const results = resultsForCode(await spectral.run(document), 'unsupported-media-type')


### PR DESCRIPTION
This splits the rulesets into 3 different ones, with the default ruleset containing the least opinionated rules and ruleset-highest.yaml containing the most opinionated.

This is because we want to do some user testing to see how people respond to different levels of strictness, i.e. do they want a very opinionated ruleset that is prescriptive about how things should be done, or do they want a more lightweight ruleset. 

Medium ruleset:
- The semver rule has been moved into this one
- Rules for the minimum oas version, license options, operation-id and kebab case for paths

Highest ruleset:
- This has stricter rules on the oas version and license
- The not acceptable and unsupported media type rules have been moved into this one

Each ruleset builds on the previous one, so for example the medium ruleset extends the default one and the highest extends the medium one.

At the moment all of the rules are error level, but we might want to change some of them to warning level later on.