### PR TITLE
Include rulesets in package

### DIFF
--- a/spectral-ruleset-govuk-public/package-lock.json
+++ b/spectral-ruleset-govuk-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "OGL-UK-3.0",
       "devDependencies": {
         "@jamietanna/spectral-test-harness": "^0.2.0",

--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Spectral ruleset for public UK government APIs",
   "main": "ruleset.yaml",
+  "files": [
+    "ruleset-*.yaml"
+  ],
   "license": "OGL-UK-3.0",
   "devDependencies": {
     "@jamietanna/spectral-test-harness": "^0.2.0",


### PR DESCRIPTION
We want people to be able to use multiple rulesets that we make available in this package. This should make sure that files following the naming pattern `ruleset-*.yaml` are included, so people can choose which to extend.