### PR TITLE
Extend the ruleset from the npm package

### DIFF
--- a/spectral-ruleset-govuk-public/README.md
+++ b/spectral-ruleset-govuk-public/README.md
@@ -76,3 +76,24 @@ You can follow the instructions in the [Spectral documentation](https://meta.sto
 
 Alternatively you can install the NPM package in your repository as described above, and run it as you would any NPM package. An example of this using Github Actions can be found in the [federated API model repository](https://github.com/co-cddo/federated-api-model/blob/main/.github/workflows/openapi-docs-pr.yml).
 
+## Rulesets
+
+There are 3 different rulesets available in this NPM package. The default ruleset is the least opinionated. There are two more rulesets that are increasingly opinionated, `ruleset-medium.yaml` and `ruleset-high.yaml`. `ruleset-high.yaml` is the most opinionated of the 3 rulesets.
+
+To use either the medium or high rulesets, you can specify this in your `.spectral.yaml` file. For example to use the medium one:
+
+```yaml
+extends:
+  - '@govuk-data-standards/spectral-ruleset-govuk-public/ruleset-medium.yaml'
+formats:
+  - "oas3.1"
+```
+
+You can also use the ruleset via HTTPS url, for example to use the medium ruleset:
+
+```yaml
+extends:
+  - https://raw.githubusercontent.com/co-cddo/api-standards-linting/spectral-ruleset-govuk-public-v0.3.0/spectral-ruleset-govuk-public/ruleset-medium.yaml
+formats:
+  - "oas3.1"
+```

--- a/spectral-ruleset-govuk-public/package-lock.json
+++ b/spectral-ruleset-govuk-public/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.7.2",
       "license": "OGL-UK-3.0",
       "devDependencies": {
+        "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.7.1",
         "@jamietanna/spectral-test-harness": "^0.3.0",
         "jest": "^29.5.0",
         "standard": "^17.0.0"
@@ -49,21 +50,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
+        "@babel/parser": "^7.21.3",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -85,12 +86,12 @@
       "dev": true
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.0",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -372,9 +373,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -575,19 +576,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.1",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.2",
-        "@babel/types": "^7.21.2",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -596,9 +597,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -701,6 +702,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@govuk-data-standards/spectral-ruleset-govuk-public": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@govuk-data-standards/spectral-ruleset-govuk-public/-/spectral-ruleset-govuk-public-0.7.2.tgz",
+      "integrity": "sha512-hKsqls2I4W/7om+t0B4bRWx6Ko0N65eXYfCbyl6SjRtCjI/tdw1GLYj0OD4BHhWUxxSAhZf3++4RbhcvzQcfkg==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -1676,9 +1683,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2122,9 +2129,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001462",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
-      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true,
       "funding": [
         {
@@ -2134,6 +2141,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -2287,9 +2298,9 @@
       "dev": true
     },
     "node_modules/deepmerge": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2351,9 +2362,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.322",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.322.tgz",
-      "integrity": "sha512-KovjizNC9XB7dno/2GjxX8VS0SlfPpCjtyoKft+bCO+UfD8bFy16hY4Sh9s0h9BDxbRH2U0zX5VBjpM1LTcNlg==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5435,9 +5446,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-      "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+      "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
       "dev": true,
       "funding": [
         {
@@ -5551,9 +5562,9 @@
       }
     },
     "node_modules/resolve.exports": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.1.tgz",
-      "integrity": "sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -6301,21 +6312,21 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
+        "@babel/parser": "^7.21.3",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -6332,12 +6343,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.21.0",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -6559,9 +6570,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -6702,27 +6713,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.1",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.2",
-        "@babel/types": "^7.21.2",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -6802,6 +6813,12 @@
           "dev": true
         }
       }
+    },
+    "@govuk-data-standards/spectral-ruleset-govuk-public": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@govuk-data-standards/spectral-ruleset-govuk-public/-/spectral-ruleset-govuk-public-0.7.2.tgz",
+      "integrity": "sha512-hKsqls2I4W/7om+t0B4bRWx6Ko0N65eXYfCbyl6SjRtCjI/tdw1GLYj0OD4BHhWUxxSAhZf3++4RbhcvzQcfkg==",
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -7624,9 +7641,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -7947,9 +7964,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001462",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
-      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true
     },
     "chalk": {
@@ -8063,9 +8080,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "define-properties": {
@@ -8106,9 +8123,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.322",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.322.tgz",
-      "integrity": "sha512-KovjizNC9XB7dno/2GjxX8VS0SlfPpCjtyoKft+bCO+UfD8bFy16hY4Sh9s0h9BDxbRH2U0zX5VBjpM1LTcNlg==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "dev": true
     },
     "emittery": {
@@ -10398,9 +10415,9 @@
       "dev": true
     },
     "pure-rand": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-      "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+      "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
       "dev": true
     },
     "react-is": {
@@ -10471,9 +10488,9 @@
       "dev": true
     },
     "resolve.exports": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.1.tgz",
-      "integrity": "sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true
     },
     "rimraf": {

--- a/spectral-ruleset-govuk-public/package-lock.json
+++ b/spectral-ruleset-govuk-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "OGL-UK-3.0",
       "devDependencies": {
         "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.7.1",

--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-data-standards/spectral-ruleset-govuk-public",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Spectral ruleset for public UK government APIs",
   "main": "ruleset.yaml",
   "files": [

--- a/spectral-ruleset-govuk-public/package.json
+++ b/spectral-ruleset-govuk-public/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "@jamietanna/spectral-test-harness": "^0.3.0",
     "jest": "^29.5.0",
-    "standard": "^17.0.0"
+    "standard": "^17.0.0",
+    "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.7.1"
   },
   "scripts": {
     "lint": "standard",

--- a/spectral-ruleset-govuk-public/ruleset-high.yaml
+++ b/spectral-ruleset-govuk-public/ruleset-high.yaml
@@ -1,5 +1,5 @@
 extends:
-  - 'ruleset-medium.yaml'
+  - '@govuk-data-standards/spectral-ruleset-govuk-public/ruleset-medium.yaml'
 rules:
   oas3-strict:
     documentationUrl: https://cddo-api-spec-linter.herokuapp.com/rules/oas3-strict

--- a/spectral-ruleset-govuk-public/ruleset-medium.yaml
+++ b/spectral-ruleset-govuk-public/ruleset-medium.yaml
@@ -1,5 +1,5 @@
 extends:
-  - 'ruleset.yaml'
+  - '@govuk-data-standards/spectral-ruleset-govuk-public'
 rules:
   oas3-minimum:
     documentationUrl: https://cddo-api-spec-linter.herokuapp.com/rules/oas3-minimum


### PR DESCRIPTION
We were previously using local file paths to extend the other rulesets
in this package. This works for the tests but not for someone using the other rulesets
via npm. So instead the ruleset should extend the rulesets from the npm package.

This also means we have to include the npm package itself as a `devDependency`
so that the tests will work.